### PR TITLE
Register SRID -1 and 0

### DIFF
--- a/src/ogc_sql.rs
+++ b/src/ogc_sql.rs
@@ -110,7 +110,7 @@ pub(crate) fn sql_insert_feature(layer_name: &str, columns: &str, values: &str) 
 
 pub(crate) fn initialize_gpkg(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
     conn.execute_batch(SQL_GPKG_SPATIAL_REF_SYS)?;
-    ensure_srs_4326(conn)?;
+    register_default_srs_ids(conn)?;
     conn.execute_batch(SQL_GPKG_CONTENTS)?;
     conn.execute_batch(SQL_GPKG_GEOMETRY_COLUMNS)?;
     conn.execute_batch(SQL_GPKG_TILE_MATRIX_SET)?;
@@ -151,14 +151,37 @@ CREATE TABLE gpkg_spatial_ref_sys (
 
 // This is a bit horrible part. gpkg_spatial_ref_sys requires the WKT of the SRS, but we don't have a good source for this.
 // Adding 4326 is easy, but what should I do to support other SRS?
-fn ensure_srs_4326(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
+fn register_default_srs_ids(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
     const EPSG4326_WKT: &str = r#"GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]"#;
 
-    conn.execute(
-        "INSERT INTO gpkg_spatial_ref_sys \
+    let sql = "INSERT INTO gpkg_spatial_ref_sys \
             (srs_name, srs_id, organization, organization_coordsys_id, definition, description) \
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)";
+    conn.execute(
+        sql,
         rusqlite::params!["WGS 84", 4326, "EPSG", 4326, EPSG4326_WKT, "WGS 84"],
+    )?;
+    conn.execute(
+        sql,
+        rusqlite::params![
+            "Undefined Cartesian SRS",
+            -1,
+            "NONE",
+            -1,
+            "undefined",
+            "undefined Cartesian coordinate reference system"
+        ],
+    )?;
+    conn.execute(
+        sql,
+        rusqlite::params![
+            "Undefined geographic SRS",
+            0,
+            "NONE",
+            0,
+            "undefined",
+            "undefined geographic coordinate reference system"
+        ],
     )?;
     Ok(())
 }


### PR DESCRIPTION
According to https://www.geopackage.org/spec140/index.html#r11

> The gpkg_spatial_ref_sys table SHALL contain at a minimum the records listed in Table 3. ...snip... The record with an srs_id of -1 SHALL be used for undefined Cartesian coordinate reference systems. The record with an srs_id of 0 SHALL be used for undefined geographic coordinate reference systems.