### PR TITLE
fix: Fix geometry column's type name

### DIFF
--- a/src/gpkg/gpkg.rs
+++ b/src/gpkg/gpkg.rs
@@ -324,7 +324,7 @@ impl Gpkg {
 
         let mut column_defs = Vec::with_capacity(other_column_specs.len() + 2);
         column_defs.push("fid INTEGER PRIMARY KEY AUTOINCREMENT".to_string());
-        column_defs.push(format!(r#""{}" BLOB"#, geometry_column));
+        column_defs.push(format!(r#""{}" {geometry_type_name}"#, geometry_column));
         for spec in other_column_specs {
             let col_type = column_type_to_str(spec.column_type);
             column_defs.push(format!(r#""{}" {col_type}"#, spec.name));


### PR DESCRIPTION
<https://www.geopackage.org/spec140/index.html>:

> The declared SQL type of the geometry column in a vector feature user data table SHALL be specified by the geometry_type_name column for that column_name and table_name in the gpkg_geometry_columns table.