### PR TITLE
ci: Use `gdal driver gpkg validate`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,9 @@ jobs:
         run: |
           for f in /tmp/rusqlite_gpkg_dump_*.gpkg; do
             echo "Validating ${f}..."
-            docker run --rm -v "${f}:/tmp/validate.gpkg:ro" \
+            docker run --rm -v "/tmp:/tmp:ro" \
               ghcr.io/osgeo/gdal:alpine-normal-3.13.0beta1 \
-              gdal driver gpkg validate /tmp/validate.gpkg
+              gdal driver gpkg validate "${f}"
           done
 
   wasm:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,14 @@ jobs:
       - name: Test arrow features
         run: cargo test --features arrow
 
-      - name: Validate GeoPackage files with GDAL
+      - name: Generate GeoPackage with write_gpkg
+        run: cargo run --features wkt --bin write_gpkg -- /tmp/test_output.gpkg
+
+      - name: Validate GeoPackage with GDAL
         run: |
-          for f in /tmp/rusqlite_gpkg_dump_*.gpkg; do
-            echo "Validating ${f}..."
-            docker run --rm -v "/tmp:/tmp:ro" \
-              ghcr.io/osgeo/gdal:alpine-normal-3.13.0beta1 \
-              gdal driver gpkg validate "${f}"
-          done
+          docker run --rm -v "/tmp/test_output.gpkg:/data/test_output.gpkg:ro" \
+            ghcr.io/osgeo/gdal:alpine-normal-3.13.0beta1 \
+            gdal driver gpkg validate /data/test_output.gpkg
 
   wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Test arrow features
         run: cargo test --features arrow
 
+      - name: Validate GeoPackage files with GDAL
+        run: |
+          for f in /tmp/rusqlite_gpkg_dump_*.gpkg; do
+            echo "Validating ${f}..."
+            docker run --rm -v "${f}:/tmp/validate.gpkg:ro" \
+              ghcr.io/osgeo/gdal:alpine-normal-3.13.0beta1 \
+              gdal driver gpkg validate /tmp/validate.gpkg
+          done
+
   wasm:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
GDAL 3.13 will add `gdal driver gpkg validate`. Let's use this on CI. Use Docker image for now, and migrate after the release of 3.13.