### PR TITLE
fix: Add application ID and update gpkg_extensions table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - Set `PRAGMA application_id` to `0x47504B47` ("GPKG") when creating a new GeoPackage, as required by the spec (#28).
+- Set `PRAGMA user_version` to `10400` (spec version 1.4.0) when creating a new GeoPackage (#28).
 - Register RTree spatial indexes in `gpkg_extensions` so other readers can discover them (#29).
 
 ## [v0.0.7] (2026-04-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### Fixed
+
+- Set `PRAGMA application_id` to `0x47504B47` ("GPKG") when creating a new GeoPackage, as required by the spec (#28).
+- Register RTree spatial indexes in `gpkg_extensions` so other readers can discover them (#29).
+
 ## [v0.0.7] (2026-04-05)
 
 ### Added

--- a/src/ogc_sql.rs
+++ b/src/ogc_sql.rs
@@ -345,5 +345,10 @@ pub(crate) fn execute_rtree_sqls(
     conn.execute_batch(&gpkg_rtree_create_sql(table, geom_column))?;
     conn.execute_batch(&gpkg_rtree_load_sql(table, geom_column, id_column))?;
     conn.execute_batch(&gpkg_rtree_triggers_sql(table, geom_column, id_column))?;
+    conn.execute(
+        "INSERT INTO gpkg_extensions (table_name, column_name, extension_name, definition, scope) \
+         VALUES (?1, ?2, 'gpkg_rtree_index', 'http://www.geopackage.org/spec/#extension_rtree', 'write-only')",
+        rusqlite::params![table, geom_column],
+    )?;
     Ok(())
 }

--- a/src/ogc_sql.rs
+++ b/src/ogc_sql.rs
@@ -111,6 +111,8 @@ pub(crate) fn sql_insert_feature(layer_name: &str, columns: &str, values: &str) 
 pub(crate) fn initialize_gpkg(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
     // 0x47504B47 = ASCII "GPKG" (GeoPackage 1.2+)
     conn.execute_batch("PRAGMA application_id = 0x47504B47;")?;
+    // 10400 = spec version 1.4.0 in MMNNPP format
+    conn.execute_batch("PRAGMA user_version = 10400;")?;
     conn.execute_batch(SQL_GPKG_SPATIAL_REF_SYS)?;
     register_default_srs_ids(conn)?;
     conn.execute_batch(SQL_GPKG_CONTENTS)?;

--- a/src/ogc_sql.rs
+++ b/src/ogc_sql.rs
@@ -109,6 +109,8 @@ pub(crate) fn sql_insert_feature(layer_name: &str, columns: &str, values: &str) 
 }
 
 pub(crate) fn initialize_gpkg(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
+    // 0x47504B47 = ASCII "GPKG" (GeoPackage 1.2+)
+    conn.execute_batch("PRAGMA application_id = 0x47504B47;")?;
     conn.execute_batch(SQL_GPKG_SPATIAL_REF_SYS)?;
     register_default_srs_ids(conn)?;
     conn.execute_batch(SQL_GPKG_CONTENTS)?;


### PR DESCRIPTION
Fix #28

Requirement 2 of [the spec](https://www.geopackage.org/spec140/index.html):

> A GeoPackage SHALL contain a value of 0x47504B47 ("GPKG" in ASCII) in the "application_id" field of the SQLite database header to indicate that it is a GeoPackage. ...snip...


---


Fix #29

Requirement 76 of [the spec](https://www.geopackage.org/spec140/index.html):

> A GeoPackage that implements spatial indexes SHALL have a gpkg_extensions table that contains a row for each spatially indexed column with extension_name "gpkg_rtree_index", the table_name of the table with a spatially indexed column, the column_name of the spatially indexed column, and a scope of "write-only".

---

Fix #31 

Requirement 2 of [the spec](https://www.geopackage.org/spec140/index.html):

> ...snip... A GeoPackage SHALL contain an appropriate value in "user_version" field of the SQLite database header to indicate its version. The value SHALL be a five-digit integer with a major version, two-digit minor version, and two-digit bug-fix. [[K4]](https://www.geopackage.org/spec140/index.html#K4)