### PR TITLE
chore: Fix wasm-pack's URL

### DIFF
--- a/.github/workflows/pages-demo.yml
+++ b/.github/workflows/pages-demo.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Install wasm-pack
         run: |
           curl -L --proto '=https' --tlsv1.2 -sSf \
-            https://github.com/drager/wasm-pack/releases/download/v0.14.0/wasm-pack-v0.14.0-x86_64-unknown-linux-musl.tar.gz \
+            https://github.com/wasm-bindgen/wasm-pack/releases/download/v0.15.0/wasm-pack-v0.15.0-x86_64-unknown-linux-musl.tar.gz \
             -o wasm-pack.tar.gz
           tar -xzf wasm-pack.tar.gz
           mkdir -p "$HOME/.local/bin"
-          mv wasm-pack-v0.14.0-x86_64-unknown-linux-musl/wasm-pack "$HOME/.local/bin/wasm-pack"
+          mv wasm-pack-v0.15.0-x86_64-unknown-linux-musl/wasm-pack "$HOME/.local/bin/wasm-pack"
           chmod +x "$HOME/.local/bin/wasm-pack"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           wasm-pack --version


### PR DESCRIPTION
It seems wasm-pack was moved back to wasm-bindgen a while ago.